### PR TITLE
removing database's implementation details from SPA components

### DIFF
--- a/src/data/dataModule.js
+++ b/src/data/dataModule.js
@@ -6,15 +6,11 @@ export default {
     logs: [],
     areas: [],
     assets: [],
-    dbReady: false,
     logCount: 0
   },
   mutations: {
     changeTestState (state, msg) {
       state.test = msg;
-    },
-    dbIsReady (state) {
-      state.dbReady = true;
     },
     iterateLogCount (state) {
       state.logCount++;
@@ -44,196 +40,207 @@ export default {
       commit('addUnsyncedLogsToState', payload())
     },
 
-/*
-Begin WebSQL actions
-*/
+    recordObservation ({commit}, obs) {
 
-makeTable ({commit}, tableRecord) {
-//Here I am both opening the database and making a new table if necessary.
+      // Pass this in to set the table name
+      const table = 'observations';
 
-  console.log('opening database');
+      openDatabase()
+      .then(function(db) {
+        return makeTable(db, table, obs)
+      })
+      .then(function(tx) {
+        saveRecord(tx, table, obs)
+      })
+    },
 
-//Check whether a local webSQL database exists.  If a local database does not yet exist, make it!
-this.db = window.openDatabase("farmOSLocalDB", "1.0", "farmOS Local Database", 200000);
-// window.openDatabase either opens an existing DB or creates a new one.
-
-      console.log('making table');
-    //Creates a table called 'tableName' in the DB if none yet exists
-
-      console.log('with the following data template:');
-      console.log(tableRecord);
-
-    this.db.transaction(
-      function (tx) {
-        //I will start by eraising all preexisting records
-          tx.executeSql('DROP TABLE IF EXISTS observations');
-
-          var fieldString = "";
-          for (var i in tableRecord){
-            fieldString = fieldString+i+" VARCHAR(50), ";
-          }
-          //I need to trim the last two characters to avoid a trailing comma
-          fieldString = fieldString.substring(0, fieldString.length - 2);
-
-          console.log("create table strings")
-          console.log(fieldString);
-
-          //the id field will autoincrement beginning with 1
-          var sql = "CREATE TABLE IF NOT EXISTS " +
-          "observations " +
-          "( id INTEGER PRIMARY KEY AUTOINCREMENT, " +
-          /*"text VARCHAR(50), " +
-          "plantings VARCHAR(50), " +
-          "locations VARCHAR(50), " +
-          "livestock VARCHAR(50) " + */
-          fieldString +
-          ")";
-
-          tx.executeSql(sql, null,
-          function () {
-              console.log('Make table success');
-              commit('dbIsReady');
-          },
-
-          function (tx, error) {
-              console.log('Make table error: ' + error.message);
-          });
-
-      }); //end db.transaction and function tx
-
-    }, // end makeTable
-
-
-    // Save a log to the local database.
-    saveLog ({commit}, tableRecord) {
-      console.log('adding record');
-
-  this.db.transaction(
-    function (tx) {
-
-      var fieldString = "";
-      var queryString = "";
-      var values = [];
-      for (var i in tableRecord){
-        fieldString = fieldString+i+", ";
-        queryString = queryString+"?, ";
-        values.push(tableRecord[i]);
-      }
-      //I need to trim the last two characters of each string to avoid trailing commas
-      fieldString = fieldString.substring(0, fieldString.length - 2);
-      queryString = queryString.substring(0, queryString.length - 2);
-
-      console.log("add record strings")
-      console.log(fieldString);
-      console.log(queryString);
-      console.log(values);
-
-      //I am going to try skipping the id field, and see if it autoincrements
-      var sql = "INSERT OR REPLACE INTO " +
-          "observations " +
-          "("+fieldString+") " +
-          "VALUES ("+queryString+")";
-
-          /*
-          "(text, plantings, locations, livestock) " +
-          "VALUES (?, ?, ?, ?)";
-          */
-
-      //tx.executeSql(sql, [tableRecord.text, tableRecord.plantings, tableRecord.locations, tableRecord.livestock],
-tx.executeSql(sql, values,
-        function () {
-          console.log('INSERT success');
-          commit('iterateLogCount');
-        },
-
-        function (tx, error) {
-          console.log('INSERT error: ' + error.message);
-        }
-      );
-
-    }//end function tx
-  ); // end transaction
-
-}, //end action saveLog
-
-getLogs ({commit}, tableRecord) {
-
-  //Get a record from the local DB by local ID.
-      //This is an asynchronous callback.
-      console.log('getting record');
-
-      //I am avoiding using jQuery $.Deferred()
-      //var deferred = $.Deferred();
-
-      //This is called if the db.transaction obtains data
-      function dataHandler(tx, results) {
-        console.log(results);
-
-        //Create an array to populate with result strings
-        //Each string consists of all data from a single DB row
-        var displayResults = [];
-
-        for (var i = 0; i < results.rows.length; i++) {
-        var oneResult = results.rows.item(i);
-        var resultString = '';
-        for (var j in oneResult){
-          resultString = resultString+j+": "+oneResult[j]+", ";
-        }
-        //var resultString = "ID: "+firstResult.id+" TEXT: "+firstResult.text+" PLANTINGS: "+firstResult.plantings+" LOCATIONS: "+firstResult.locations+" LIVESTOCK: "+firstResult.livestock;
-        console.log(resultString);
-        //Set status text within the newly created self scope
-        displayResults.push(resultString);
-        } //end results for
-        //deferred.resolve(resultString);
-
-        commit('addUnsyncedLogsToState', displayResults);
-      }
-
-      //This is called if the db.transaction fails to obtain data
-      function errorHandler(tx, error) {
-        console.log('INSERT error: ' + error.message);
-
-        //deferred.reject("Transaction Error: " + error.message);
-      }
-
-      this.db.transaction(
-
-      function (tx) {
-        //Disabling query, and simply returning all records
-        /*
-        // String together all record fields, with id as the first
-          var queryString = '';
-          for (var i in tableRecord){
-            queryString = queryString+i+", "
-          }
-          // And trim the last two characters to avoid a syntax error
-          queryString = queryString.substring(0, queryString.length - 2);
-          console.log('Querying the following DB records:');
-          console.log(queryString);
-          */
-          var sql = "SELECT " +
-              " * " +
-              //queryString +
-              "FROM " +
-              "observations ";
-              //"WHERE id=? ";
-
-              tx.executeSql(sql, [],
-          //tx.executeSql(sql, [idToGet],
-            //I am bringing the dataHandler and errorHandler functions outside of this.db.transaction
-            dataHandler,
-            errorHandler
-          ); //end executeSql
-        } // end function tx
-      ); //end this.db.transaction
-
-      //return deferred.promise();
-}, //end action getLogs
-
+    getLogs ({commit}, obs) {
+      openDatabase()
+      .then(function(db) {
+        return getLogs(db, obs)
+      })
+      .then(function(results) {
+        commit('addUnsyncedLogsToState', results)
+      })
+    },
 
     // Push records to farmOS via REST API.
     pushRecords () {
       // AJAX request...
     },
   }
+}
+
+function openDatabase () {
+  return new Promise(function(resolve, reject) {
+    //Here I am both opening the database and making a new table if necessary.
+
+    console.log('opening database');
+    //Check whether a local webSQL database exists.  If a local database does not yet exist, make it!
+    const db = window.openDatabase("farmOSLocalDB", "1.0", "farmOS Local Database", 200000);
+    // window.openDatabase either opens an existing DB or creates a new one.
+    console.log("db instance from openDatabase(): ", db);
+    resolve(db);
+
+  })
+
+
+}
+
+function makeTable(db, table, tableRecord) {
+  return new Promise(function(resolve, reject) {
+    console.log("db instance from makeTable", db);
+    console.log('making table');
+    //Creates a table called 'tableName' in the DB if none yet exists
+
+    console.log('with the following data template:');
+    console.log(tableRecord);
+    db.transaction(function (tx) {
+      //I will start by eraising all preexisting records
+      tx.executeSql(`DROP TABLE IF EXISTS ${table}`);
+
+      var fieldString = "";
+      for (var i in tableRecord){
+        fieldString = fieldString+i+" VARCHAR(50), ";
+      }
+      //I need to trim the last two characters to avoid a trailing comma
+      fieldString = fieldString.substring(0, fieldString.length - 2);
+
+      console.log("create table strings")
+      console.log(fieldString);
+
+      //the id field will autoincrement beginning with 1
+      var sql = "CREATE TABLE IF NOT EXISTS " +
+      table +
+      " ( id INTEGER PRIMARY KEY AUTOINCREMENT, " +
+      /*"text VARCHAR(50), " +
+      "plantings VARCHAR(50), " +
+      "locations VARCHAR(50), " +
+      "livestock VARCHAR(50) " + */
+      fieldString +
+      ")";
+
+      console.log("tx instance from makeTable(): ", tx);
+      tx.executeSql(sql, null, function (_tx, result) {
+        console.log('Make table success. Result: ', result);
+        resolve(_tx);
+      }, function (_tx, error) {
+        console.log('Make table error: ' + error.message);
+        // Reject will return the tx object in case you want to try again.
+        reject(_tx);
+      });
+
+    });
+
+  })
+}
+
+// Save a log to the local database.
+function saveRecord (tx, table, tableRecord) {
+  console.log("tx instance from saveRecord(): ", tx);
+  console.log('adding record');
+  var fieldString = "";
+  var queryString = "";
+  var values = [];
+  for (var i in tableRecord){
+    fieldString = fieldString+i+", ";
+    queryString = queryString+"?, ";
+    values.push(tableRecord[i]);
+  }
+  //I need to trim the last two characters of each string to avoid trailing commas
+  fieldString = fieldString.substring(0, fieldString.length - 2);
+  queryString = queryString.substring(0, queryString.length - 2);
+
+  console.log("add record strings")
+  console.log(fieldString);
+  console.log(queryString);
+  console.log(values);
+
+  //I am going to try skipping the id field, and see if it autoincrements
+  var sql = "INSERT OR REPLACE INTO " +
+  table +
+  " ("+fieldString+") " +
+  "VALUES ("+queryString+")";
+
+  /*
+  "(text, plantings, locations, livestock) " +
+  "VALUES (?, ?, ?, ?)";
+  */
+
+  //tx.executeSql(sql, [tableRecord.text, tableRecord.plantings, tableRecord.locations, tableRecord.livestock],
+  tx.executeSql(sql, values, function () {
+    console.log('INSERT success');
+    // commit('iterateLogCount');
+  }, function (_tx, error) {
+    console.log('INSERT error: ' + error.message);
+  });
+}
+
+function getLogs (db, tableRecord) {
+  return new Promise(function(resolve, reject) {
+    //Get a record from the local DB by local ID.
+    //This is an asynchronous callback.
+    console.log('getting record');
+
+    //I am avoiding using jQuery $.Deferred()
+    //var deferred = $.Deferred();
+
+    //This is called if the db.transaction obtains data
+    function dataHandler(tx, results) {
+      console.log(results);
+
+      //Create an array to populate with result strings
+      //Each string consists of all data from a single DB row
+      var displayResults = [];
+
+      for (var i = 0; i < results.rows.length; i++) {
+        var oneResult = results.rows.item(i);
+        var resultString = '';
+        for (var j in oneResult){
+          resultString = resultString+j+": "+oneResult[j]+", ";
+        }
+        //var resultString = "ID: "+firstResult.id+" TEXT: "+firstResult.text+" PLANTINGS: "+firstResult.plantings+" LOCATIONS: "+firstResult.locations+" LIVESTOCK: "+firstResult.livestock;
+        console.log("resultString", resultString);
+        //Set status text within the newly created self scope
+        displayResults.push(resultString);
+      } //end results for
+      //deferred.resolve(resultString);
+
+      resolve(displayResults);
+      // commit('addUnsyncedLogsToState', displayResults);
+    }
+
+    //This is called if the db.transaction fails to obtain data
+    function errorHandler(tx, error) {
+      reject('INSERT error: ' + error.message);
+
+      //deferred.reject("Transaction Error: " + error.message);
+    }
+
+    db.transaction(function (tx) {
+      //Disabling query, and simply returning all records
+      // // String together all record fields, with id as the first
+      // var queryString = '';
+      // for (var i in tableRecord){
+      //   queryString = queryString+i+", "
+      // }
+      // // And trim the last two characters to avoid a syntax error
+      // queryString = queryString.substring(0, queryString.length - 2);
+      // console.log('Querying the following DB records:');
+      // console.log(queryString);
+      var sql = "SELECT " +
+      " * " +
+      //queryString +
+      "FROM " +
+      "observations ";
+      //"WHERE id=? ";
+
+      tx.executeSql(sql, [],
+        //tx.executeSql(sql, [idToGet],
+        //I am bringing the dataHandler and errorHandler functions outside of this.db.transaction
+        dataHandler,
+        errorHandler
+      );
+    });
+  })
 }

--- a/src/spa/components/NewObservation.vue
+++ b/src/spa/components/NewObservation.vue
@@ -95,7 +95,6 @@ export default {
   computed: mapState({
         dataTestState: state => state.data.test,
         logs: state => state.data.logs,
-        dbReady: state => state.data.dbReady,
         logCount: state => state.data.logCount
       }),
 
@@ -135,17 +134,6 @@ export default {
   created: function () {
     this.$store.dispatch('loadCachedLogs');
   },
-  watch: {
-  dbReady: { // watch newRecord to see when it increments
-    handler: function(newVal, oldVal) {
-      //Execute when changes are made
-      this.$store.dispatch('saveLog', this.observation);
-    },
-    //deep: true
-  }
-}, // end watch
-
-
   methods: {
     /* Disable this temporarily; may move to dataModule store ###
     loadDefaultObservations () {
@@ -161,7 +149,7 @@ export default {
     recordObservation () {
       console.log('Observation recorded');
       //Open database and create new table if needed
-      this.$store.dispatch('makeTable', this.observation);
+      this.$store.dispatch('recordObservation', this.observation);
       //I am using a watcher on dbReady, which will change to true when table is made.  I will then save the log.
 
       //this.DataModule.$emit('didSubmitObservation', this.observation);


### PR DESCRIPTION
@alexadamsmith , if you're free tomorrow afternoon, perhaps we could go over these changes and do a merge together.

Main thing is I wanted to remove WebSQL implementation details from the NewObservations component, as well as from the data plugin's state and mutations. It's really best to confine SQL details to the store's actions, and if needed, create helper functions that aren't properties on the store but which be called in from outside it (also need to be careful about using `this` keyword from within the store). I'm worried those things could lead to breaking changes in a the web-based offline module, which won't be implemented with SQL tables or have the need to watch for the DB to be ready.

I'm also using promises to pass on database and transaction instances from one async call to the next, which I think makes the thread of execution a lot easier to follow. We can go over all that too; should be a good example for getting the feel for promises and how handy they can be for async.