### PR TITLE
Moving state back to SPA and subscribing to mutations

### DIFF
--- a/src/data/dataModule.js
+++ b/src/data/dataModule.js
@@ -29,7 +29,7 @@ export default {
 
   actions: {
 
-    initializeLog({commit, rootState}, logType) {
+    initializeLog({commit, dispatch, rootState}, logType) {
       // TODO: The User ID will also be needed to sync with server
       const curDate = new Date(Date.now());
       const timestamp = Math.floor(curDate / 1000).toString();
@@ -42,24 +42,24 @@ export default {
         timestamp: timestamp,
       });
       commit('addLogAndMakeCurrent', newLog);
+      dispatch('createRecord', newLog);
+    },
 
-      // TODO: Separate this into its own action
-      let newRecord = newLog;
+    createRecord ({commit, dispatch, rootstate}, newRecord) {
+      const tableName = newRecord.type
       delete newRecord.local_id
       openDatabase()
       .then(function(db) {
-        return makeTable(db, logType, newRecord);
+        return makeTable(db, tableName, newRecord);
       })
       .then(function(tx) {
-        return saveRecord(tx, logType, newRecord)
+        return saveRecord(tx, tableName, newRecord)
       })
       .then(function(results) {
         // Can we be sure this will always be the CURRENT log?
         commit('updateCurrentLog', { key: 'isCachedLocally', val: true });
         commit('updateCurrentLog', { key: 'local_id', val: results.insertId });
-
       })
-
     },
 
     loadCachedLogs({commit}, logType) {

--- a/src/data/dataModule.js
+++ b/src/data/dataModule.js
@@ -13,6 +13,7 @@ export default {
       const cachedLogs = payload.map(function(cachedLog) {
         return logFactory({
           ...cachedLog,
+          // TODO: The DB action should set `isCachedLocally` before committing
           isCachedLocally: true
         })
       });
@@ -29,7 +30,14 @@ export default {
 
   actions: {
 
-    initializeLog({commit, dispatch, rootState}, logType) {
+    // INPUT ACTION
+    initializeLogs ({commit, dispatch}, logType) {
+      dispatch('createLog', logType);
+      dispatch('loadCachedLogs', logType);
+    },
+
+    // INPUT ACTION
+    createLog({commit, dispatch, rootState}, logType) {
       // TODO: The User ID will also be needed to sync with server
       const curDate = new Date(Date.now());
       const timestamp = Math.floor(curDate / 1000).toString();
@@ -45,6 +53,7 @@ export default {
       dispatch('createRecord', newLog);
     },
 
+    // DB ACTION
     createRecord ({commit, dispatch, rootstate}, newRecord) {
       const tableName = newRecord.type
       delete newRecord.local_id
@@ -62,6 +71,7 @@ export default {
       })
     },
 
+    // DB ACTION
     loadCachedLogs({commit}, logType) {
       openDatabase()
       .then(function(db) {
@@ -75,6 +85,7 @@ export default {
       })
     },
 
+    // INPUT ACTION
     updateCurrentLog({commit, dispatch, rootState}, newProperty) {
       commit('updateCurrentLog', newProperty);
       let newLog = logFactory({
@@ -84,6 +95,7 @@ export default {
       dispatch('updateRecord', newLog);
     },
 
+    // DB ACTION
     updateRecord ({commit}, newLog) {
       const table = newLog.type;
       openDatabase()

--- a/src/data/dataModule.js
+++ b/src/data/dataModule.js
@@ -15,9 +15,12 @@ export default {
     addLogAndMakeCurrent(state, newLog) {
       state.currentLogIndex = state.logs.push(newLog) -1;
     },
-    // TODO: accept multiple properties
-    updateCurrentLog (state, newProperty) {
-      state.logs[state.currentLogIndex][newProperty.key] = newProperty.val
+    updateCurrentLog (state, newProps) {
+      const updatedLog = logFactory({
+        ...state.logs[state.currentLogIndex],
+        ...newProps
+      });
+      state.logs.splice(state.currentLogIndex, 1, updatedLog);
     },
   },
 
@@ -60,8 +63,11 @@ export default {
       })
       .then(function(results) {
         // Can we be sure this will always be the CURRENT log?
-        commit('updateCurrentLog', { key: 'isCachedLocally', val: true });
-        commit('updateCurrentLog', { key: 'local_id', val: results.insertId });
+        // Not if we use this action to add new records received from the server
+        commit('updateCurrentLog', {
+          local_id: results.insertId,
+          isCachedLocally: true
+        });
       })
     },
 
@@ -86,12 +92,13 @@ export default {
     },
 
     // INPUT ACTION
-    updateCurrentLog({commit, dispatch, rootState}, newProperty) {
-      commit('updateCurrentLog', newProperty);
+    updateCurrentLog({commit, dispatch, rootState}, newProps) {
+      commit('updateCurrentLog', newProps);
+      // TODO: updateRecord should build the new log and be passed newProps instead
       let newLog = logFactory({
-        ...rootState.data.logs[rootState.data.currentLogIndex]
-      })
-      newLog[newProperty.key] = newProperty.val;
+        ...rootState.data.logs[rootState.data.currentLogIndex],
+        ...newProps
+      });
       dispatch('updateRecord', newLog);
     },
 
@@ -107,7 +114,7 @@ export default {
       })
       .then(function(tx, result) {
         // Can we be sure this will always be the CURRENT log?
-        commit('updateCurrentLog', { key: 'isCachedLocally', val: true })
+        commit('updateCurrentLog', { isCachedLocally: true })
       })
     },
 

--- a/src/data/dataModule.js
+++ b/src/data/dataModule.js
@@ -22,19 +22,18 @@ export default {
       });
       state.logs.splice(state.currentLogIndex, 1, updatedLog);
     },
+    clearLogs (state, payload) {
+      state.logs.splice(0, state.logs.length);
+    }
   },
 
   actions: {
 
     // INPUT ACTION
-    initializeLogs ({commit, dispatch}, logType) {
-      // BUG: This is creating duplicate records on startup
-      dispatch('createLog', logType);
-      dispatch('loadCachedLogs', logType);
-    },
-
-    // INPUT ACTION
-    createLog({commit, dispatch, rootState}, logType) {
+    // TODO: Should this logic be moved to the 'addLogAndMakeCurrent' mutation?
+    //    Or perhaps just the logFactory, and pass in the date and logType as
+    //    a `newProps` object from a component method.
+    initializeLog({commit, rootState}, logType) {
       // TODO: The User ID will also be needed to sync with server
       const curDate = new Date(Date.now());
       const timestamp = Math.floor(curDate / 1000).toString();
@@ -47,7 +46,6 @@ export default {
         timestamp: timestamp,
       });
       commit('addLogAndMakeCurrent', newLog);
-      dispatch('createRecord', newLog);
     },
 
     // DB ACTION
@@ -91,19 +89,12 @@ export default {
       })
     },
 
-    // INPUT ACTION
-    updateCurrentLog({commit, dispatch, rootState}, newProps) {
-      commit('updateCurrentLog', newProps);
-      // TODO: updateRecord should build the new log and be passed newProps instead
-      let newLog = logFactory({
+    // DB ACTION
+    updateRecord ({commit, rootState}, newProps) {
+      const newLog = logFactory({
         ...rootState.data.logs[rootState.data.currentLogIndex],
         ...newProps
       });
-      dispatch('updateRecord', newLog);
-    },
-
-    // DB ACTION
-    updateRecord ({commit}, newLog) {
       const table = newLog.type;
       openDatabase()
       .then(function(db) {

--- a/src/data/dataModule.js
+++ b/src/data/dataModule.js
@@ -1,54 +1,9 @@
 import {logFactory} from './logFactory';
 
 export default {
-  state: {
-    logs: [],
-    assets: [],
-    areas: [],
-    currentLogIndex: 0,
-  },
-
-  mutations: {
-    addLogs(state, logs) {
-      state.logs = state.logs.concat(logs);
-    },
-    addLogAndMakeCurrent(state, newLog) {
-      state.currentLogIndex = state.logs.push(newLog) -1;
-    },
-    updateCurrentLog (state, newProps) {
-      const updatedLog = logFactory({
-        ...state.logs[state.currentLogIndex],
-        ...newProps
-      });
-      state.logs.splice(state.currentLogIndex, 1, updatedLog);
-    },
-    clearLogs (state, payload) {
-      state.logs.splice(0, state.logs.length);
-    }
-  },
 
   actions: {
 
-    // INPUT ACTION
-    // TODO: Should this logic be moved to the 'addLogAndMakeCurrent' mutation?
-    //    Or perhaps just the logFactory, and pass in the date and logType as
-    //    a `newProps` object from a component method.
-    initializeLog({commit, rootState}, logType) {
-      // TODO: The User ID will also be needed to sync with server
-      const curDate = new Date(Date.now());
-      const timestamp = Math.floor(curDate / 1000).toString();
-      const curTimeString = curDate.toLocaleTimeString('en-US');
-      const curDateString = curDate.toLocaleDateString('en-US');
-      const newLog = logFactory({
-        type: logType,
-        name: `Observation: ${curDateString} - ${curTimeString}`,
-        field_farm_log_owner: rootState.user.name ? rootState.user.name : '',
-        timestamp: timestamp,
-      });
-      commit('addLogAndMakeCurrent', newLog);
-    },
-
-    // DB ACTION
     createRecord ({commit, dispatch, rootstate}, newRecord) {
       const tableName = newRecord.type
       delete newRecord.local_id
@@ -69,7 +24,6 @@ export default {
       })
     },
 
-    // DB ACTION
     loadCachedLogs({commit}, logType) {
       openDatabase()
       .then(function(db) {
@@ -89,10 +43,9 @@ export default {
       })
     },
 
-    // DB ACTION
     updateRecord ({commit, rootState}, newProps) {
       const newLog = logFactory({
-        ...rootState.data.logs[rootState.data.currentLogIndex],
+        ...rootState.farm.logs[rootState.farm.currentLogIndex],
         ...newProps
       });
       const table = newLog.type;

--- a/src/data/index.js
+++ b/src/data/index.js
@@ -1,7 +1,21 @@
 import dataModule from './dataModule';
 
 export default {
-  install(Vue, {store}) {
+  install(Vue, {store, router}) {
     store.registerModule('data', dataModule);
+    router.afterEach( (to, from) => {
+      if (to.name === 'NewObservation') {
+        store.commit('clearLogs');
+        store.dispatch('loadCachedLogs', 'farm_observation');
+      }
+    });
+    store.subscribe( (mutation, state) => {
+      if (mutation.type === 'addLogAndMakeCurrent') {
+        store.dispatch('createRecord', mutation.payload);
+      }
+      if (mutation.type === 'updateCurrentLog' && !mutation.payload.isCachedLocally) {
+        store.dispatch('updateRecord', mutation.payload);
+      }
+    });
   }
 }

--- a/src/data/logFactory.js
+++ b/src/data/logFactory.js
@@ -1,16 +1,9 @@
 // A helper function for creating new log items with default properties
 export function logFactory ({
-  field_farm_images = [],
-  // TODO: Are we allowing for multiple images/uris?
-  local_image_uris = [],
-  field_farm_area = [],
-  field_farm_asset = [],
-  field_farm_geofield = [],
   // TODO: Owner should be identified by user id, once we have authentication
-  field_farm_log_owner = '',
-  field_farm_notes = '',
-  // TODO: Should this be a number, or should the view be able to handle multiple inputs?
-  field_farm_quantity = [],
+  log_owner = '',
+  notes = '',
+  quantity = '',
   id = null,
   local_id = null,
   name = '',
@@ -18,60 +11,11 @@ export function logFactory ({
   timestamp = '',
   done = false,
   isCachedLocally = false,
-  // TODO: A timestamp might be better than a boolean for tracking remote sync
-  isSyncedWithServer = false,
-} = {}, dest) {
-  if (dest === 'SQL') {
-    // Return a different format if outputting for SQL
-    return {
-      field_farm_images,
-      local_image_uris,
-      field_farm_area,
-      field_farm_asset,
-      field_farm_geofield,
-      field_farm_log_owner,
-      field_farm_notes,
-      field_farm_quantity,
-      id,
-      local_id,
-      name,
-      type,
-      timestamp,
-      done,
-      isCachedLocally,
-      isSyncedWithServer,
-    };
-  } else if (dest === 'STORE') {
-    // Return a different format if outputting for the Vuex Store
-    return {
-      field_farm_images,
-      local_image_uris,
-      field_farm_area,
-      field_farm_asset,
-      field_farm_geofield,
-      field_farm_log_owner,
-      field_farm_notes,
-      field_farm_quantity,
-      id,
-      local_id,
-      name,
-      type,
-      timestamp,
-      done,
-      isCachedLocally,
-      isSyncedWithServer,
-    };
-  }
-  // A default to return if no destination is specified
+} = {}) {
   return {
-    field_farm_images,
-    local_image_uris,
-    field_farm_area,
-    field_farm_asset,
-    field_farm_geofield,
-    field_farm_log_owner,
-    field_farm_notes,
-    field_farm_quantity,
+    log_owner,
+    notes,
+    quantity,
     id,
     local_id,
     name,
@@ -79,6 +23,5 @@ export function logFactory ({
     timestamp,
     done,
     isCachedLocally,
-    isSyncedWithServer,
   };
 }

--- a/src/data/logFactory.js
+++ b/src/data/logFactory.js
@@ -1,5 +1,4 @@
 // A helper function for creating new log items with default properties
-// TODO: a User ID will also be needed to sync with server
 export function logFactory ({
   field_farm_images = [],
   // TODO: Are we allowing for multiple images/uris?
@@ -21,7 +20,49 @@ export function logFactory ({
   isCachedLocally = false,
   // TODO: A timestamp might be better than a boolean for tracking remote sync
   isSyncedWithServer = false,
-} = {}) {
+} = {}, dest) {
+  if (dest === 'SQL') {
+    // Return a different format if outputting for SQL
+    return {
+      field_farm_images,
+      local_image_uris,
+      field_farm_area,
+      field_farm_asset,
+      field_farm_geofield,
+      field_farm_log_owner,
+      field_farm_notes,
+      field_farm_quantity,
+      id,
+      local_id,
+      name,
+      type,
+      timestamp,
+      done,
+      isCachedLocally,
+      isSyncedWithServer,
+    };
+  } else if (dest === 'STORE') {
+    // Return a different format if outputting for the Vuex Store
+    return {
+      field_farm_images,
+      local_image_uris,
+      field_farm_area,
+      field_farm_asset,
+      field_farm_geofield,
+      field_farm_log_owner,
+      field_farm_notes,
+      field_farm_quantity,
+      id,
+      local_id,
+      name,
+      type,
+      timestamp,
+      done,
+      isCachedLocally,
+      isSyncedWithServer,
+    };
+  }
+  // A default to return if no destination is specified
   return {
     field_farm_images,
     local_image_uris,
@@ -39,5 +80,5 @@ export function logFactory ({
     done,
     isCachedLocally,
     isSyncedWithServer,
-  }
+  };
 }

--- a/src/spa/components/NewObservation.vue
+++ b/src/spa/components/NewObservation.vue
@@ -25,8 +25,8 @@
       </div>
       <div class="input-group">
         <input
-          :value="logs[currentLogIndex].field_farm_notes"
-          @input="updateCurrentLog('field_farm_notes', $event.target.value)"
+          :value="logs[currentLogIndex].notes"
+          @input="updateCurrentLog('notes', $event.target.value)"
           placeholder="Enter notes"
           type="text"
           class="form-control"
@@ -34,8 +34,8 @@
       </div>
       <div class="input-group">
         <input
-          :value="logs[currentLogIndex].field_farm_quantity"
-          @input="updateCurrentLog('field_farm_quantity', $event.target.value)"
+          :value="logs[currentLogIndex].quantity"
+          @input="updateCurrentLog('quantity', $event.target.value)"
           placeholder="Enter quantity"
           type="number"
           min="0"

--- a/src/spa/components/NewObservation.vue
+++ b/src/spa/components/NewObservation.vue
@@ -78,8 +78,11 @@ export default {
     },
 
     updateCurrentLog (key, val) {
-      const newProperty = {key, val};
-      this.$store.dispatch('updateCurrentLog', newProperty)
+      const newProps = {
+        [key]: val,
+        isCachedLocally: false
+      };
+      this.$store.dispatch('updateCurrentLog', newProps)
     },
 
   },

--- a/src/spa/components/NewObservation.vue
+++ b/src/spa/components/NewObservation.vue
@@ -65,7 +65,12 @@ export default {
   }),
 
   created: function () {
-    this.$store.dispatch('initializeLogs', 'farm_observation')
+    // TODO: It probably makes more sense to remember the last log the user was working on,
+    //    and only initialize a new log when they deliberately choose to.
+    this.$store.dispatch('initializeLog', 'farm_observation')
+  },
+  beforeDestroy: function () {
+    this.$store.commit('clearLogs')
   },
   methods: {
 
@@ -82,7 +87,7 @@ export default {
         [key]: val,
         isCachedLocally: false
       };
-      this.$store.dispatch('updateCurrentLog', newProps)
+      this.$store.commit('updateCurrentLog', newProps)
     },
 
   },

--- a/src/spa/components/NewObservation.vue
+++ b/src/spa/components/NewObservation.vue
@@ -60,8 +60,8 @@ export default {
     }
   },
   computed: mapState({
-    logs: state => state.data.logs,
-    currentLogIndex: state => state.data.currentLogIndex,
+    logs: state => state.farm.logs,
+    currentLogIndex: state => state.farm.currentLogIndex,
   }),
 
   created: function () {

--- a/src/spa/components/NewObservation.vue
+++ b/src/spa/components/NewObservation.vue
@@ -65,8 +65,7 @@ export default {
   }),
 
   created: function () {
-    this.$store.dispatch('loadCachedLogs', 'farm_observation');
-    this.$store.dispatch('initializeLog', 'farm_observation')
+    this.$store.dispatch('initializeLogs', 'farm_observation')
   },
   methods: {
 

--- a/src/spa/loader.js
+++ b/src/spa/loader.js
@@ -9,7 +9,7 @@ Vue.config.productionTip = false;
 
 export default (data, login) => {
   // TODO: Error handling for required args, better control flow for optional args
-  Vue.use(data, {store})
+  Vue.use(data, {store, router})
   if (typeof login !== 'undefined') {
     Vue.use(login, {router, store})
   }

--- a/src/spa/store/index.js
+++ b/src/spa/store/index.js
@@ -1,5 +1,6 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
+import {logFactory} from '../../data/logFactory';
 
 Vue.use(Vuex);
 
@@ -14,8 +15,56 @@ const shellModule = {
   },
 }
 
+const farmModule = {
+  state: {
+    test: 'some state',
+    logs: [],
+    assets: [],
+    areas: [],
+    currentLogIndex: 0,
+  },
+  mutations: {
+    addLogs(state, logs) {
+      state.logs = state.logs.concat(logs);
+    },
+    addLogAndMakeCurrent(state, newLog) {
+      state.currentLogIndex = state.logs.push(newLog) -1;
+    },
+    updateCurrentLog (state, newProps) {
+      const updatedLog = logFactory({
+        ...state.logs[state.currentLogIndex],
+        ...newProps
+      });
+      state.logs.splice(state.currentLogIndex, 1, updatedLog);
+    },
+    clearLogs (state, payload) {
+      state.logs.splice(0, state.logs.length);
+    }
+  },
+  actions: {
+    // TODO: Should this logic be moved to the 'addLogAndMakeCurrent' mutation?
+    //    Or perhaps just the logFactory, and pass in the date and logType as
+    //    a `newProps` object from a component method.
+    initializeLog({commit, rootState}, logType) {
+      // TODO: The User ID will also be needed to sync with server
+      const curDate = new Date(Date.now());
+      const timestamp = Math.floor(curDate / 1000).toString();
+      const curTimeString = curDate.toLocaleTimeString('en-US');
+      const curDateString = curDate.toLocaleDateString('en-US');
+      const newLog = logFactory({
+        type: logType,
+        name: `Observation: ${curDateString} - ${curTimeString}`,
+        field_farm_log_owner: rootState.user.name ? rootState.user.name : '',
+        timestamp: timestamp,
+      });
+      commit('addLogAndMakeCurrent', newLog);
+    },
+  }
+}
+
 export default new Vuex.Store({
   modules: {
     shell: shellModule,
+    farm: farmModule
   }
 })

--- a/src/spa/store/index.js
+++ b/src/spa/store/index.js
@@ -1,6 +1,6 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
-import {logFactory} from '../../data/logFactory';
+import {logFactory} from './logFactory';
 
 Vue.use(Vuex);
 
@@ -24,6 +24,7 @@ const farmModule = {
   },
   mutations: {
     addLogs(state, logs) {
+      // TODO: Should logs pass through logFactory() to make sure props are valid?
       state.logs = state.logs.concat(logs);
     },
     addLogAndMakeCurrent(state, newLog) {

--- a/src/spa/store/index.js
+++ b/src/spa/store/index.js
@@ -53,7 +53,7 @@ const farmModule = {
       const newLog = logFactory({
         type: logType,
         name: `Observation: ${curDateString} - ${curTimeString}`,
-        field_farm_log_owner: rootState.user.name ? rootState.user.name : '',
+        log_owner: rootState.user.name ? rootState.user.name : '',
         timestamp: timestamp,
       });
       commit('addLogAndMakeCurrent', newLog);

--- a/src/spa/store/index.js
+++ b/src/spa/store/index.js
@@ -17,7 +17,6 @@ const shellModule = {
 
 const farmModule = {
   state: {
-    test: 'some state',
     logs: [],
     assets: [],
     areas: [],

--- a/src/spa/store/logFactory.js
+++ b/src/spa/store/logFactory.js
@@ -1,0 +1,27 @@
+// A helper function for creating new log items with default properties
+export function logFactory ({
+  // TODO: Owner should be identified by user id, once we have authentication
+  log_owner = '',
+  notes = '',
+  quantity = '',
+  id = null,
+  local_id = null,
+  name = '',
+  type = '',
+  timestamp = '',
+  done = false,
+  isCachedLocally = false,
+} = {}) {
+  return {
+    log_owner,
+    notes,
+    quantity,
+    id,
+    local_id,
+    name,
+    type,
+    timestamp,
+    done,
+    isCachedLocally,
+  };
+}


### PR DESCRIPTION
Up until now, actions dispatched from the SPA components would make their changes to the state in the data plugin, then dispatch calls to corresponding db actions to reflect those changes in SQL. For instance,  the`updateCurrentLog()` action would commit new user inputs to the `updateCurrentLog()` mutation, then dispatch another action to the `updateRecord()` which would make the changes in SQL.

With this PR, UI actions/mutations no longer directly call db actions; instead the data plugin "listens" for UI-generated mutations, then dispatches any corresponding db actions itself. This is done within the plugin's `install()` method (in the main `data/index.js` file), by invoking `store.subscribe()` to listen for user-generated mutations, and using the provided callback to dispatch the appropriate db actions. The one exception is for when the NewObservations component first loads and we want to preload all logs from the db; to do that, we set a hook with `router.afterEach()`, but it basically works the same. 

Now that the UI actions/mutations no longer need to dispatch the db actions directly, that frees us to entirely separate those UI actions, mutations and even the state for the logs themselves from the data plugin and move them back to the SPA. That leaves the data plugin with just a small set of actions, and some utility functions, which are wholly concerned with database operations; no state of its own, it only mutates the properties of the log objects which specifically pertain to local storage: `local_id` and `isCachedLocally`. 

With this separation, I've also created 2 versions of logFactory(), one for the data plugin, and one for the SPA. They're exact duplicates for now, both extremely simplified, but they can (and probably should) diverge as we go along. `data/logFactory.js` can have methods for serializing the logs before they go into SQL, or formatting them as object literals before commiting them to the store, or as JSON before posting to the server. Comparatively, the `spa/store/logFactory.js` will be much more narrowly focused on generating the format needed for the store only; it will probably need to validate the properties of incoming logs that were dispatched from the data plugin, but it won't actually know anything about their source or its implementation. So the onus is really on the data plugin to make sure the SPA store gets logs formatted the way the SPA store wants (kinda the same way the data plugin will be responsible for making sure the server gets logs formatted the way the server wants).